### PR TITLE
Implement Phase 3: Teams Web Mock Automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          playwright install chromium
 
       - name: Run HID Verification
         run: ./scripts/run_ci.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 venv/
 *.png
 !templates/*.png
+*.log

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,27 +5,29 @@ Diese Roadmap beschreibt die Schritte zur Umsetzung des Konzepts in ausführbare
 ## Phase 1: Vorbereitung der Umgebung
 Ziel: Eine konsistente Laufzeitumgebung für lokale Entwicklung und CI schaffen.
 
-- [ ] **Lokal (Ubuntu):**
+- [x] **Lokal (Ubuntu):**
     - Installation von `python3`, `pip`, `xvfb` (für Headless-Tests).
     - Setup virtueller Python-Umgebungen.
-- [ ] **GitHub Actions:**
+- [x] **GitHub Actions:**
     - Erstellung eines Workflows, der einen virtuellen Framebuffer (Xvfb) startet, um GUI-Apps ohne Monitor auszuführen.
     - Installation der notwendigen Abhängigkeiten in der CI-Pipeline.
 
 ## Phase 2: HID Emulations-Layer
 Ziel: Simulation von USB-HID Signalen ohne physische Hardware.
 
-- [ ] **Recherche & Auswahl:**
+- [x] **Recherche & Auswahl:**
     - Evaluierung von `python-evdev` oder `uinput` zur Erstellung virtueller Eingabegeräte.
     - Alternative: Nutzung von `pyautogui` für Standard-Key-Events, falls HID-spezifische Page-IDs nicht direkt emuliert werden können (Hinweis: Für echten HID-Nachweis ist `evdev` bevorzugt).
-- [ ] **Implementierung `hid_simulator.py`:**
+- [x] **Implementierung `hid_simulator.py`:**
     - Skript zum Senden von `Telephony: Phone Mute` (0x0B, 0x2F).
     - Skript zum Senden von `Consumer: Mute` (0x0C, 0xE2).
 
 ## Phase 3: Teams Automatisierung
 Ziel: Microsoft Teams fernsteuern und in einen Call-Zustand bringen.
 
-- [ ] **Installation:**
+- [x] **Mock-Automatisierung (CI-ready):**
+    - Simulation des Teams-Web-Interfaces zur Verifizierung der HID-Logik ohne echte Teams-Installation.
+- [ ] **Installation (Echtbetrieb):**
     - Automatisierte Installation von Microsoft Teams (Linux-Client oder Web-App via Selenium/Playwright).
 - [ ] **Workflow-Skript:**
     - Starten von Teams.
@@ -35,9 +37,9 @@ Ziel: Microsoft Teams fernsteuern und in einen Call-Zustand bringen.
 ## Phase 4: Visuelle Verifizierung
 Ziel: Automatisierte Erfolgskontrolle durch Bildanalyse.
 
-- [ ] **Referenz-Bilder:**
+- [x] **Referenz-Bilder:**
     - Erstellen von Templates für das "Mute"-Icon und "Unmute"-Icon in Teams.
-- [ ] **Implementierung `image_verifier.py`:**
+- [x] **Implementierung `image_verifier.py`:**
     - Screenshot des Teams-Fensters erstellen.
     - Nutzung von `OpenCV` oder `PIL` zum Abgleich mit den Templates.
     - Rückgabe eines Boolean-Werts (Success/Fail).
@@ -45,7 +47,7 @@ Ziel: Automatisierte Erfolgskontrolle durch Bildanalyse.
 ## Phase 5: CI/CD Integration (GitHub Actions)
 Ziel: Vollautomatische Tests bei jedem Push.
 
-- [ ] **Workflow-Definition:**
+- [x] **Workflow-Definition:**
     - Trigger bei Push auf `main` oder Pull Requests.
     - Matrix-Builds (optional für verschiedene Teams-Versionen).
     - Upload der Screenshots als Artefakte im Fehlerfall zur Fehlersuche.

--- a/scripts/mock_teams_web.html
+++ b/scripts/mock_teams_web.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Microsoft Teams</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #f3f2f1;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .call-container {
+            background-color: #242424;
+            width: 80%;
+            height: 80%;
+            border-radius: 8px;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            color: white;
+            position: relative;
+        }
+        .controls {
+            position: absolute;
+            bottom: 20px;
+            display: flex;
+            gap: 20px;
+            background-color: rgba(0,0,0,0.5);
+            padding: 10px 20px;
+            border-radius: 30px;
+        }
+        .control-btn {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            cursor: pointer;
+            border: none;
+            outline: none;
+        }
+        #mute-btn {
+            background-color: white;
+            color: black;
+        }
+        #mute-btn.muted {
+            background-color: #d83b01;
+            color: white;
+        }
+        .status-label {
+            font-size: 24px;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="call-container">
+        <div id="status" class="status-label">Mic Active</div>
+        <div class="controls">
+            <button id="mute-btn" class="control-btn" onclick="toggleMute()">🎙️</button>
+            <button class="control-btn" style="background-color: #d83b01; color: white;">📞</button>
+        </div>
+    </div>
+
+    <script>
+        let isMuted = false;
+        const muteBtn = document.getElementById('mute-btn');
+        const statusLabel = document.getElementById('status');
+
+        function toggleMute() {
+            isMuted = !isMuted;
+            if (isMuted) {
+                muteBtn.classList.add('muted');
+                statusLabel.innerText = 'Muted';
+                console.log('Teams Status: MUTED');
+            } else {
+                muteBtn.classList.remove('muted');
+                statusLabel.innerText = 'Mic Active';
+                console.log('Teams Status: UNMUTED');
+            }
+        }
+
+        window.addEventListener('keydown', (event) => {
+            // 'm' is the shortcut for mute in Teams
+            if (event.key.toLowerCase() === 'm') {
+                toggleMute();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/scripts/run_ci.sh
+++ b/scripts/run_ci.sh
@@ -28,12 +28,23 @@ MOCK_PID=$!
 # Wait for UI to initialize
 sleep 5
 
-# 3. Run the verification script
-echo "Running hid_verify.py..."
+# 3. Run the verification scripts
+echo "Running hid_verify.py (Desktop Mock)..."
 set +e
 python3 scripts/hid_verify.py
-RESULT=$?
+RESULT_DESKTOP=$?
+
+echo "Running teams_web_automation.py (Web Mock)..."
+python3 scripts/teams_web_automation.py
+RESULT_WEB=$?
 set -e
+
+# Calculate overall result
+if [ $RESULT_DESKTOP -eq 0 ] && [ $RESULT_WEB -eq 0 ]; then
+    RESULT=0
+else
+    RESULT=1
+fi
 
 # 4. Cleanup
 echo "Cleaning up Mock UI (PID: $MOCK_PID)..."

--- a/scripts/teams_web_automation.py
+++ b/scripts/teams_web_automation.py
@@ -1,32 +1,79 @@
 import asyncio
 from playwright.async_api import async_playwright
 import os
+import sys
+import logging
+from hid_simulator import simulate_hid_event
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout)
+    ]
+)
+logger = logging.getLogger(__name__)
+
+async def verify_mute_state(page, expected_muted):
+    """
+    Verifies the mute state in the DOM.
+    """
+    status_text = await page.inner_text("#status")
+    is_muted = "Muted" in status_text
+
+    if is_muted == expected_muted:
+        logger.info(f"DOM Verification: {'Muted' if expected_muted else 'Unmuted'} - SUCCESS")
+        return True
+    else:
+        logger.error(f"DOM Verification: Expected {'Muted' if expected_muted else 'Unmuted'}, but got {'Muted' if is_muted else 'Unmuted'} - FAILED")
+        return False
 
 async def main():
     async with async_playwright() as p:
-        # Launch browser
-        browser = await p.chromium.launch(headless=True)
+        # Launch browser - headless=False is needed for pyautogui to interact with the window in Xvfb
+        browser = await p.chromium.launch(headless=False)
         context = await browser.new_context()
         page = await context.new_page()
 
-        print("Navigating to Microsoft Teams...")
+        # Path to our mock web app
+        file_path = os.path.abspath("scripts/mock_teams_web.html")
+        url = f"file://{file_path}"
+
+        logger.info(f"Navigating to Mock Teams Web: {url}")
         try:
-            # Go to Teams Web App
-            await page.goto("https://teams.microsoft.com")
+            await page.goto(url)
+            await page.wait_for_selector("#mute-btn")
 
-            # Wait for some content to load or redirect to login
-            await page.wait_for_timeout(5000)
+            # Initial state should be unmuted
+            if not await verify_mute_state(page, False):
+                sys.exit(1)
 
-            title = await page.title()
-            print(f"Page Title: {title}")
+            # 1. Simulate Mute (Telephony Page 0x0B, Usage 0x2F)
+            logger.info("Triggering Mute HID event...")
+            simulate_hid_event(0x0B, 0x2F)
+            await page.wait_for_timeout(1000) # Wait for UI to update
 
-            # Take a screenshot for verification
-            screenshot_path = "teams_web_init.png"
-            await page.screenshot(path=screenshot_path)
-            print(f"Screenshot saved to {screenshot_path}")
+            if not await verify_mute_state(page, True):
+                sys.exit(1)
+
+            # Take a screenshot for visual verification
+            await page.screenshot(path="web_mute_success.png")
+
+            # 2. Simulate Unmute (Toggle back)
+            logger.info("Triggering Unmute HID event...")
+            simulate_hid_event(0x0B, 0x2F)
+            await page.wait_for_timeout(1000)
+
+            if not await verify_mute_state(page, False):
+                sys.exit(1)
+
+            await page.screenshot(path="web_unmute_success.png")
+            logger.info("Teams Web Automation: ALL TESTS PASSED")
 
         except Exception as e:
-            print(f"Error during Teams Web automation: {e}")
+            logger.error(f"Error during Teams Web automation: {e}")
+            sys.exit(1)
         finally:
             await browser.close()
 


### PR DESCRIPTION
This PR implements the "Teams Automation" phase of the roadmap by introducing a mock-based automation strategy suitable for CI/CD environments where a full Microsoft Teams installation is not feasible.

Key changes:
1. **Mock Web Application**: Added `scripts/mock_teams_web.html`, which provides a minimal Teams-like calling UI. It responds to the standard 'm' key shortcut for muting, allowing us to verify HID-triggered events in a browser context.
2. **Automation Script**: Refactored `scripts/teams_web_automation.py` to use Playwright for navigating the mock web app, triggering HID events via `hid_simulator.py`, and verifying the resulting DOM state.
3. **CI Integration**: Updated `scripts/run_ci.sh` to run both the existing desktop mock verification (`hid_verify.py`) and the new web mock verification.
4. **Project Maintenance**: Updated `.gitignore` to keep the workspace clean and refined the `ROADMAP.md` to accurately represent current project progress and future goals.

All verification steps passed successfully in the simulated Xvfb environment.

Fixes #13

---
*PR created automatically by Jules for task [4934624114598376324](https://jules.google.com/task/4934624114598376324) started by @chatelao*