### PR TITLE
Real Teams Instance and Screenshot Standardization

### DIFF
--- a/scripts/hid_verify.py
+++ b/scripts/hid_verify.py
@@ -25,7 +25,10 @@ def run_verification_cycle(page, usage, template_path, label):
         logger.error(f"Failed to simulate HID event for {label}")
         return False
 
-    screenshot = capture_screenshot()
+    # Use descriptive name for screenshots in hid_verify
+    screenshot_name = f"screenshots/desktop_{label.lower().replace(' ', '_')}.png"
+    screenshot = capture_screenshot(screenshot_name)
+
     if verify_template(screenshot, template_path):
         logger.info(f"{label} Verification: SUCCESS")
         return True

--- a/scripts/image_verifier.py
+++ b/scripts/image_verifier.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 logger = logging.getLogger(__name__)
 
-def capture_screenshot():
+def capture_screenshot(custom_path=None):
     """
     Captures a screenshot of the primary monitor.
     """
@@ -24,10 +24,14 @@ def capture_screenshot():
             sct_img = sct.grab(monitor)
             screenshot = Image.frombytes("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
 
-            # Save for debugging
-            debug_path = f"screenshots/debug_screenshot_{int(time.time())}.png"
-            screenshot.save(debug_path)
-            logger.info(f"Saved debug screenshot to {debug_path}")
+            # Save path
+            if custom_path:
+                save_path = custom_path
+            else:
+                save_path = f"screenshots/debug_screenshot_{int(time.time())}.png"
+
+            screenshot.save(save_path)
+            logger.info(f"Saved screenshot to {save_path}")
             return screenshot
 
     except Exception as e:

--- a/scripts/real_teams_web_automation.py
+++ b/scripts/real_teams_web_automation.py
@@ -58,14 +58,12 @@ async def verify_real_mute_state(page, expected_muted):
         return False
 
 async def main():
-    if len(sys.argv) < 2 or not sys.argv[1]:
-        logger.error("Usage: python scripts/real_teams_web_automation.py <meeting_url>")
-        # We don't exit with error here to allow CI to pass if no URL is provided,
-        # but we log the requirement.
-        logger.info("Skipping real Teams execution: No meeting URL provided or URL is empty.")
-        return
+    meeting_url = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else "https://teams.microsoft.com/v2/"
 
-    meeting_url = sys.argv[1]
+    if meeting_url == "https://teams.microsoft.com/v2/":
+        logger.info("No meeting URL provided. Defaulting to Teams Web Portal to ensure real instance is called.")
+    else:
+        logger.info(f"Using meeting URL: {meeting_url}")
 
     async with async_playwright() as p:
         # headless=False is required for pyautogui HID simulation to hit the browser window
@@ -79,6 +77,7 @@ async def main():
 
         logger.info(f"Navigating to Teams Meeting: {meeting_url}")
         await page.goto(meeting_url)
+        await page.screenshot(path="screenshots/real_teams_initial_load.png")
 
         try:
             # 1. Handle Launcher/Landing Page
@@ -87,6 +86,7 @@ async def main():
                 # Common landing page button for Web join
                 continue_btn = page.locator("button:has-text('Continue on this browser'), [data-tid='joinOnWeb']")
                 await continue_btn.wait_for(state="visible", timeout=15000)
+                await page.screenshot(path="screenshots/real_teams_landing_page.png")
                 await continue_btn.click()
                 logger.info("Clicked 'Continue on this browser'")
             except Exception as e:
@@ -115,6 +115,7 @@ async def main():
             if name_input:
                 await name_input.fill("HID-Compliance-Tester")
                 logger.info("Filled guest name.")
+                await page.screenshot(path="screenshots/real_teams_prejoin_filled.png")
 
                 # Join Now button
                 join_btn = page.locator("button[data-tid='prejoin-join-button'], button:has-text('Join now')")
@@ -132,6 +133,7 @@ async def main():
             try:
                 await page.wait_for_selector(mic_button_sel, timeout=60000)
                 logger.info("Entered meeting UI.")
+                await page.screenshot(path="screenshots/real_teams_meeting_ui.png")
             except:
                 logger.error("Timed out waiting for meeting UI (Mic button).")
                 await page.screenshot(path="screenshots/real_teams_join_timeout.png")

--- a/scripts/teams_web_automation.py
+++ b/scripts/teams_web_automation.py
@@ -54,10 +54,11 @@ async def main():
             await page.wait_for_timeout(1000) # Wait for UI to update
 
             if not await verify_mute_state(page, True):
+                await page.screenshot(path="screenshots/web_mock_mute_telephony_fail.png")
                 sys.exit(1)
 
             # Take a screenshot for visual verification
-            await page.screenshot(path="screenshots/web_mute_telephony_success.png")
+            await page.screenshot(path="screenshots/web_mock_mute_telephony_success.png")
 
             # 2. Simulate Unmute (Toggle back)
             logger.info("Triggering Unmute HID event (Telephony)...")
@@ -65,7 +66,10 @@ async def main():
             await page.wait_for_timeout(1000)
 
             if not await verify_mute_state(page, False):
+                await page.screenshot(path="screenshots/web_mock_unmute_telephony_fail.png")
                 sys.exit(1)
+
+            await page.screenshot(path="screenshots/web_mock_unmute_telephony_success.png")
 
             # 3. Simulate Consumer Mute (Consumer Page 0x0C, Usage 0xE2)
             logger.info("Triggering Consumer Mute HID event...")
@@ -77,9 +81,10 @@ async def main():
             if not await verify_mute_state(page, True):
                 # Try to log what happened
                 logger.error("Consumer Mute (simulated via 0x0B) failed in web mock.")
+                await page.screenshot(path="screenshots/web_mock_mute_consumer_fail.png")
                 sys.exit(1)
 
-            await page.screenshot(path="screenshots/web_mute_consumer_success.png")
+            await page.screenshot(path="screenshots/web_mock_mute_consumer_success.png")
 
             # 4. Simulate Unmute (Toggle back via Consumer)
             logger.info("Triggering Unmute HID event (Consumer)...")
@@ -87,9 +92,10 @@ async def main():
             await page.wait_for_timeout(1000)
 
             if not await verify_mute_state(page, False):
+                await page.screenshot(path="screenshots/web_mock_unmute_consumer_fail.png")
                 sys.exit(1)
 
-            await page.screenshot(path="screenshots/web_unmute_success.png")
+            await page.screenshot(path="screenshots/web_mock_unmute_consumer_success.png")
             logger.info("Teams Web Automation: ALL TESTS PASSED")
 
         except Exception as e:


### PR DESCRIPTION
This change ensures that the HID compliance verification process always includes a real Microsoft Teams instance (via the Teams Web Portal if no specific meeting URL is provided). Additionally, it standardizes and enhances the screenshot capture logic across all verification scripts, ensuring that all visual evidence is preserved with descriptive filenames in the `screenshots/` directory, which is collected as a CI artifact.

Fixes #25

---
*PR created automatically by Jules for task [8842423133349416981](https://jules.google.com/task/8842423133349416981) started by @chatelao*