### PR TITLE
Configure Chromium flags and context for Playwright tests

### DIFF
--- a/scripts/real_teams_web_automation.py
+++ b/scripts/real_teams_web_automation.py
@@ -63,6 +63,7 @@ async def verify_real_mute_state(page, expected_muted):
 
 async def main():
     meeting_url = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else "https://teams.microsoft.com/v2/"
+    user_creds = os.environ.get("TEAMS_USER")
 
     if meeting_url == "https://teams.microsoft.com/v2/":
         logger.info("No meeting URL provided. Defaulting to Teams Web Portal. Note: This usually requires login.")
@@ -71,7 +72,15 @@ async def main():
 
     async with async_playwright() as p:
         # headless=False is preferred for pyautogui interaction in Xvfb.
-        browser = await p.chromium.launch(headless=False)
+        browser = await p.chromium.launch(
+            headless=False,
+            args=[
+                "--use-fake-ui-for-media-stream",
+                "--use-fake-device-for-media-stream",
+                "--disable-notifications",
+                "--no-sandbox",
+            ]
+        )
         context = await browser.new_context(
             viewport={'width': 1280, 'height': 720},
             permissions=["microphone", "camera"],

--- a/scripts/teams_web_automation.py
+++ b/scripts/teams_web_automation.py
@@ -24,8 +24,20 @@ async def verify_mute_state(page, expected_muted):
 async def main():
     async with async_playwright() as p:
         # Launch browser - headless=False is needed for pyautogui to interact with the window in Xvfb
-        browser = await p.chromium.launch(headless=False)
-        context = await browser.new_context()
+        browser = await p.chromium.launch(
+            headless=False,
+            args=[
+                "--use-fake-ui-for-media-stream",
+                "--use-fake-device-for-media-stream",
+                "--disable-notifications",
+                "--no-sandbox",
+            ]
+        )
+        context = await browser.new_context(
+            viewport={'width': 1280, 'height': 720},
+            permissions=["microphone", "camera"],
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        )
         page = await context.new_page()
 
         # Log console messages


### PR DESCRIPTION
This change updates the Playwright browser configuration in both the mock and real Teams automation scripts. Specifically, it adds Chromium launch flags for fake media streams, disables notifications, and skips the sandbox. It also standardizes the browser context settings (viewport, permissions, and user agent) and adds environment variable handling for `TEAMS_USER` in `real_teams_web_automation.py`. Verification was performed using `scripts/run_ci.sh`, confirming successful browser initialization and mock test execution.

Fixes #33

---
*PR created automatically by Jules for task [17748205996013700644](https://jules.google.com/task/17748205996013700644) started by @chatelao*