### PR TITLE
Fix Real Teams Pre-join Mute Failure

### DIFF
--- a/REAL_MUTE_NOT_WORKING.md
+++ b/REAL_MUTE_NOT_WORKING.md
@@ -1,0 +1,18 @@
+# Ursachenanalyse: Mute-Fehler auf dem Real Teams Pre-join Screen
+
+Die Datei `real_teams_prejoin_muted_test.png` zeigte, dass die Stummschaltung über HID-Events auf dem echten Microsoft Teams Pre-join Screen nicht wie erwartet funktionierte. Die Analyse ergab zwei Hauptursachen:
+
+## 1. Fokus-Konflikt im Eingabefeld
+Im Automatisierungsskript `real_teams_web_automation.py` wird das Namensfeld für Gäste ausgefüllt (`HID-Compliance-Tester`). Unmittelbar danach wird das HID-Event simuliert.
+- **Problem:** Der Fokus bleibt nach dem Ausfüllen im Texteingabefeld.
+- **Auswirkung:** Das simulierte Tastatur-Event (derzeit nur die Taste 'm') wird als Text in das Eingabefeld geschrieben, anstatt von Microsoft Teams als globaler Shortcut erkannt zu werden.
+
+## 2. Inkorrekter Tastatur-Shortcut
+Der `hid_simulator.py` verwendet derzeit die Taste `m` zur Simulation von `Telephony Mute` (0x0B, 0x2F).
+- **Problem:** Während einige Applikationen 'm' unterstützen, ist der offizielle und zuverlässige Shortcut für Microsoft Teams (Web & Desktop) `Strg+Umschalt+M` (Ctrl+Shift+M).
+- **Auswirkung:** Selbst wenn kein Fokus-Konflikt bestünde, würde ein einfaches 'm' im Web-Client unter Umständen nicht ausreichen, um den Mute-Status zuverlässig zu toggeln, besonders wenn die Seite nicht korrekt auf einfache Tastendrücke reagiert.
+
+## Geplante Korrekturmaßnahmen
+1. **Shortcut-Update:** Änderung des `hid_simulator.py`, sodass `Telephony Mute` den Shortcut `Strg+Umschalt+M` verwendet.
+2. **Fokus-Management:** Anpassung von `real_teams_web_automation.py`, um das aktive Element (Eingabefeld) vor dem Senden des HID-Signals zu verlassen (Blur), damit der Shortcut vom Browser/Teams-Framework korrekt verarbeitet werden kann.
+3. **Mock-Synchronisation:** Aktualisierung der Mock-UIs (`mock_teams_web.html` und `mock_teams_ui.py`), um den neuen Shortcut ebenfalls zu unterstützen und die Test-Integrität zu wahren.

--- a/scripts/hid_simulator.py
+++ b/scripts/hid_simulator.py
@@ -49,8 +49,8 @@ def simulate_hid_event(page, usage):
     try:
         # Implementation using pyautogui fallback
         if page == 0x0B and usage == 0x2F:
-            logger.info("Emulating Telephony Mute (0x0B, 0x2F) via pyautogui press('m')...")
-            pyautogui.press('m')
+            logger.info("Emulating Telephony Mute (0x0B, 0x2F) via pyautogui hotkey('ctrl', 'shift', 'm')...")
+            pyautogui.hotkey('ctrl', 'shift', 'm')
         elif page == 0x0C and usage == 0xE2:
             logger.info("Emulating Consumer Mute (0x0C, 0xE2) via pyautogui press('volumemute')...")
             pyautogui.press('volumemute')

--- a/scripts/mock_teams_ui.py
+++ b/scripts/mock_teams_ui.py
@@ -1,6 +1,9 @@
 import tkinter as tk
 import sys
 import os
+from logger_config import setup_logger
+
+logger = setup_logger(__name__)
 
 class MockTeamsUI:
     def __init__(self, root):
@@ -21,9 +24,19 @@ class MockTeamsUI:
         self.root.focus_force()
 
     def on_key(self, event):
-        print(f"Key pressed: {event.keysym}")
+        # Support 'm', XF86AudioMute, and Ctrl+Shift+M (standard Teams shortcut)
+        # In Tkinter, Ctrl+Shift+M can come as 'M' with specific state
+        is_ctrl = (event.state & 0x4) != 0
+        is_shift = (event.state & 0x1) != 0
+
+        print(f"Key pressed: {event.keysym}, state: {event.state}")
+
         if event.keysym in ('m', 'M', 'XF86AudioMute'):
-            self.toggle_mute()
+            if event.keysym in ('m', 'M') and is_ctrl and is_shift:
+                logger.info("Detected Ctrl+Shift+M shortcut")
+                self.toggle_mute()
+            elif event.keysym == 'XF86AudioMute' or (event.keysym.lower() == 'm' and not is_ctrl):
+                self.toggle_mute()
 
     def toggle_mute(self, event=None):
         self.is_muted = not self.is_muted

--- a/scripts/mock_teams_web.html
+++ b/scripts/mock_teams_web.html
@@ -167,7 +167,10 @@
                  // In real teams, 'm' might not work if focus is on input, but let's allow it for testing if name is filled
             }
             // 'AudioVolumeMute' is a common keysym for the mute button
-            if (event.key.toLowerCase() === 'm' || event.key === 'AudioVolumeMute' || event.code === 'AudioVolumeMute' || event.keyCode === 173 || event.keyCode === 181) {
+            const isMuteKey = event.key.toLowerCase() === 'm' || event.key === 'AudioVolumeMute' || event.code === 'AudioVolumeMute' || event.keyCode === 173 || event.keyCode === 181;
+            const isTeamsShortcut = event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'm';
+
+            if (isMuteKey || isTeamsShortcut) {
                 if (inCall) {
                     toggleMute();
                 } else {

--- a/scripts/real_teams_web_automation.py
+++ b/scripts/real_teams_web_automation.py
@@ -7,6 +7,17 @@ from logger_config import setup_logger
 
 logger = setup_logger(__name__)
 
+async def safe_screenshot(page, path):
+    """
+    Safely captures a screenshot, catching protocol errors that can happen in
+    certain headless environments.
+    """
+    try:
+        await page.screenshot(path=path)
+        logger.info(f"Screenshot saved to {path}")
+    except Exception as e:
+        logger.warning(f"Failed to capture screenshot {path}: {e}")
+
 async def verify_real_mute_state(page, expected_muted):
     """
     Verifies the mute state in the real Teams DOM.
@@ -95,7 +106,7 @@ async def main():
             logger.error(f"Initial navigation failed: {e}")
 
         await page.wait_for_timeout(5000)
-        await page.screenshot(path="screenshots/real_teams_initial_load.png")
+        await safe_screenshot(page, "screenshots/real_teams_initial_load.png")
 
         try:
             # 1. Handle Launcher/Landing Page (The "How do you want to join?" screen)
@@ -130,7 +141,7 @@ async def main():
                     # JavaScript fallback click
                     await page.evaluate("btn => btn.click()", await launcher_btn.element_handle())
                     await page.wait_for_timeout(5000)
-                    await page.screenshot(path="screenshots/real_teams_after_launcher.png")
+                    await safe_screenshot(page, "screenshots/real_teams_after_launcher.png")
                     break
                 else:
                     logger.info("Waiting for launcher button to appear...")
@@ -150,7 +161,7 @@ async def main():
                 # Check for Sign-in redirect
                 if "login.microsoftonline.com" in url or "login.live.com" in url:
                     logger.error("Redirected to a Sign-in page. This meeting likely requires an account or the guest link is invalid.")
-                    await page.screenshot(path="screenshots/real_teams_signin_blocked.png")
+                    await safe_screenshot(page, "screenshots/real_teams_signin_blocked.png")
                     break
 
                 # Check if we are ALREADY in the meeting
@@ -166,7 +177,7 @@ async def main():
                 for indicator in lobby_indicators:
                     if await page.locator(f"text='{indicator}'").count() > 0:
                         logger.info(f"Detected Lobby (Indicator: '{indicator}'). Waiting...")
-                        await page.screenshot(path="screenshots/real_teams_lobby_state.png")
+                        await safe_screenshot(page, "screenshots/real_teams_lobby_state.png")
                         in_lobby = True
                         break
                 if in_lobby:
@@ -189,7 +200,12 @@ async def main():
                             await found.first.fill("HID-Compliance-Tester")
                             name_filled = True
                             await page.wait_for_timeout(1000)
-                            await page.screenshot(path="screenshots/real_teams_prejoin_filled.png")
+
+                            # CRITICAL: Blur the input to ensure keyboard shortcuts work
+                            await page.evaluate("() => document.activeElement.blur()")
+                            logger.info("Blurred name input to enable global keyboard shortcuts.")
+
+                            await safe_screenshot(page, "screenshots/real_teams_prejoin_filled.png")
 
                             # Investigation: Log all buttons on pre-join screen
                             buttons = await page.locator("button").all()
@@ -210,16 +226,25 @@ async def main():
                                     prejoin_speaker_btn = btn
 
                             if prejoin_mic_btn:
+                                # Get initial state
+                                aria_before = (await prejoin_mic_btn.get_attribute("aria-label") or "").lower()
+                                logger.info(f"Pre-join mic ARIA before toggle: {aria_before}")
+
                                 logger.info("Triggering HID Telephony Mute (0x0B, 0x2F) on pre-join screen...")
                                 simulate_hid_event(0x0B, 0x2F)
                                 await page.wait_for_timeout(3000)
-                                await page.screenshot(path="screenshots/real_teams_prejoin_muted_test.png")
+                                await safe_screenshot(page, "screenshots/real_teams_prejoin_muted_test.png")
 
                                 # Verify state change
                                 aria_after = (await prejoin_mic_btn.get_attribute("aria-label") or "").lower()
                                 logger.info(f"Pre-join mic ARIA after toggle: {aria_after}")
-                                if "unmute" in aria_after or "aufheben" in aria_after:
-                                    logger.info("Pre-join HID Mute: SUCCESS")
+
+                                # In Teams, Unmute means it IS muted.
+                                muted_after = any(term in aria_after for term in ["unmute", "aufheben", "stummgeschaltet", "muted"])
+                                muted_before = any(term in aria_before for term in ["unmute", "aufheben", "stummgeschaltet", "muted"])
+
+                                if muted_after != muted_before:
+                                    logger.info(f"Pre-join HID Mute: SUCCESS (State changed from {muted_before} to {muted_after})")
                                 else:
                                     logger.warning("Pre-join HID Mute: FAILED or UI did not update ARIA label")
                             break
@@ -243,7 +268,7 @@ async def main():
                         # JS click fallback
                         await page.evaluate("btn => btn.click()", await found.first.element_handle())
                         await page.wait_for_timeout(5000)
-                        await page.screenshot(path="screenshots/real_teams_after_join_click.png")
+                        await safe_screenshot(page, "screenshots/real_teams_after_join_click.png")
                         break
 
                 await page.wait_for_timeout(4000)
@@ -251,7 +276,7 @@ async def main():
 
             if not mic_button_found:
                 logger.error("Timed out waiting for Meeting UI (Microphone button).")
-                await page.screenshot(path="screenshots/real_teams_final_failure.png")
+                await safe_screenshot(page, "screenshots/real_teams_final_failure.png")
                 return
 
             # 3. Perform HID Test - Toggle Mute
@@ -267,10 +292,10 @@ async def main():
 
             if not await verify_real_mute_state(page, not is_initial_muted):
                 logger.error("HID Mute verification failed on real Teams instance.")
-                await page.screenshot(path="screenshots/real_teams_mute_fail.png")
+                await safe_screenshot(page, "screenshots/real_teams_mute_fail.png")
             else:
                 logger.info("HID Mute verification SUCCESS on real Teams instance.")
-                await page.screenshot(path="screenshots/real_teams_mute_success.png")
+                await safe_screenshot(page, "screenshots/real_teams_mute_success.png")
 
             # 4. Perform HID Test - Toggle back
             logger.info("Triggering HID event again to toggle back...")
@@ -284,7 +309,7 @@ async def main():
 
         except Exception as e:
             logger.error(f"Error during Real Teams automation: {e}")
-            await page.screenshot(path="screenshots/real_teams_critical_error.png")
+            await safe_screenshot(page, "screenshots/real_teams_critical_error.png")
         finally:
             await browser.close()
 


### PR DESCRIPTION
Analyzed the cause of the mute failure on the real Teams pre-join screen and implemented a robust fix. The failure was caused by two factors: the keyboard shortcut used was 'm' instead of the standard 'Ctrl+Shift+M', and the focus was trapped in the guest name input field, causing the shortcut to be entered as text.

I updated the `hid_simulator.py` to use the correct shortcut, synchronized the mock environments to support it, and added focus-blurring logic to `real_teams_web_automation.py`. I also improved the automation script's resilience with a `safe_screenshot` helper and better state verification. All changes have been verified against the mock suite and through manual visual inspection.

Fixes #37

---
*PR created automatically by Jules for task [11009926896013482583](https://jules.google.com/task/11009926896013482583) started by @chatelao*