### PR TITLE
Synchronize Mock UIs with Telephony Mute shortcut

### DIFF
--- a/scripts/mock_teams_ui.py
+++ b/scripts/mock_teams_ui.py
@@ -33,7 +33,7 @@ class MockTeamsUI:
 
         if event.keysym in ('m', 'M', 'XF86AudioMute'):
             if event.keysym in ('m', 'M') and is_ctrl and is_shift:
-                logger.info("Detected Ctrl+Shift+M shortcut")
+                logger.info("Detected Telephony Mute shortcut (Ctrl+Shift+M)")
                 self.toggle_mute()
             elif event.keysym == 'XF86AudioMute' or (event.keysym.lower() == 'm' and not is_ctrl):
                 self.toggle_mute()

--- a/scripts/mock_teams_web.html
+++ b/scripts/mock_teams_web.html
@@ -171,6 +171,9 @@
             const isTeamsShortcut = event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'm';
 
             if (isMuteKey || isTeamsShortcut) {
+                if (isTeamsShortcut) {
+                    console.log("Detected Telephony Mute shortcut (Ctrl+Shift+M)");
+                }
                 if (inCall) {
                     toggleMute();
                 } else {


### PR DESCRIPTION
This change updates the logging in both the Tkinter-based Mock UI and the Playwright-based Mock Web interface to explicitly identify the 'Ctrl+Shift+M' (Strg+Umschalt+M) keyboard shortcut as the 'Telephony Mute' event.

Key changes:
- Refined shortcut detection in `scripts/mock_teams_ui.py` with descriptive logging.
- Added explicit console logging in `scripts/mock_teams_web.html` when the Teams shortcut is triggered.
- Verified that `scripts/hid_simulator.py` correctly emits this shortcut for Telephony Mute (0x0B, 0x2F).
- Successfully validated the end-to-end flow using the automated CI suite and a custom visual verification script.

Fixes #39

---
*PR created automatically by Jules for task [5124000548423328051](https://jules.google.com/task/5124000548423328051) started by @chatelao*