### PR TITLE
Fix screenshot timing and browser focus for Teams automation

### DIFF
--- a/scripts/hid_simulator.py
+++ b/scripts/hid_simulator.py
@@ -59,8 +59,6 @@ def simulate_hid_event(page, usage):
         logger.error(f"Error during pyautogui simulation of {event_name}: {e}")
         return False
 
-    # Short delay to allow UI to process the event
-    time.sleep(2)
     return True
 
 if __name__ == "__main__":

--- a/scripts/hid_verify.py
+++ b/scripts/hid_verify.py
@@ -6,6 +6,7 @@ Automated HID simulation and UI verification.
 
 import os
 import sys
+import time
 from hid_simulator import simulate_hid_event
 from image_verifier import capture_screenshot, verify_template
 from logger_config import setup_logger
@@ -24,6 +25,9 @@ def run_verification_cycle(page, usage, template_path, label):
     if not simulate_hid_event(page, usage):
         logger.error(f"Failed to simulate HID event for {label}")
         return False
+
+    # Wait for UI to update (previously handled inside simulator)
+    time.sleep(2)
 
     # Use descriptive name for screenshots in hid_verify
     screenshot_name = f"screenshots/desktop_{label.lower().replace(' ', '_')}.png"

--- a/scripts/real_teams_web_automation.py
+++ b/scripts/real_teams_web_automation.py
@@ -231,8 +231,9 @@ async def main():
                                 logger.info(f"Pre-join mic ARIA before toggle: {aria_before}")
 
                                 logger.info("Triggering HID Telephony Mute (0x0B, 0x2F) on pre-join screen...")
+                                await page.bring_to_front()
                                 simulate_hid_event(0x0B, 0x2F)
-                                await page.wait_for_timeout(3000)
+                                await page.wait_for_timeout(50)
                                 await safe_screenshot(page, "screenshots/real_teams_prejoin_muted_test.png")
 
                                 # Verify state change


### PR DESCRIPTION
This change addresses the requirement to capture the "real_teams_prejoin_muted_test.png" screenshot exactly 50ms after the HID toggle event, ensuring the browser has focus. By moving the sleep logic out of the shared HID simulator and into the specific automation scripts, we allow for the requested precision while maintaining compatibility with existing verification flows.

Fixes #41

---
*PR created automatically by Jules for task [878064743508318647](https://jules.google.com/task/878064743508318647) started by @chatelao*